### PR TITLE
実装上の問題(High+Medium)を修正: フィードバック符号反転・STM並行クラッシュ・感情判定の非決定性ほか

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -111,14 +111,21 @@ Scoring factors:
 
 ### Feedback Detection
 
-Detects memory accuracy feedback from user responses.
+Detects memory accuracy feedback from user responses. Supports Japanese and
+English, and is negation-aware (a negative correction wins over a positive cue).
 
 ```go
-delta := memai.DetectFeedback("ありがとう、そうそう！")
+delta := memai.DetectFeedback("ありがとう、そうそう！", memai.LangJapanese)
 // delta = +0.05 (positive)
 
-delta = memai.DetectFeedback("違うよ、それじゃない")
+delta = memai.DetectFeedback("違うよ、それじゃない", memai.LangJapanese)
 // delta = -0.05 (negative)
+
+delta = memai.DetectFeedback("正解じゃない", memai.LangJapanese)
+// delta = -0.05 (negation: positive token + negation suffix)
+
+delta = memai.DetectFeedback("Thanks, exactly!", memai.LangEnglish)
+// delta = +0.05 (positive)
 ```
 
 ### Storage Interface

--- a/README_ja.md
+++ b/README_ja.md
@@ -111,14 +111,20 @@ ltm.ApplyFeedback(ctx, memoryIDs, memai.FeedbackBoostPositive)
 
 ### フィードバック検出
 
-ユーザーの反応から記憶の正確性フィードバックを検出。
+ユーザーの反応から記憶の正確性フィードバックを検出。日本語・英語に対応し、否定表現を考慮する（否定が肯定に優先）。
 
 ```go
-delta := memai.DetectFeedback("ありがとう、そうそう！")
+delta := memai.DetectFeedback("ありがとう、そうそう！", memai.LangJapanese)
 // delta = +0.05 (positive)
 
-delta = memai.DetectFeedback("違うよ、それじゃない")
+delta = memai.DetectFeedback("違うよ、それじゃない", memai.LangJapanese)
 // delta = -0.05 (negative)
+
+delta = memai.DetectFeedback("正解じゃない", memai.LangJapanese)
+// delta = -0.05 (否定: 肯定語+否定接尾辞)
+
+delta = memai.DetectFeedback("Thanks, exactly!", memai.LangEnglish)
+// delta = +0.05 (positive)
 ```
 
 ### ストレージインターフェース

--- a/emotion.go
+++ b/emotion.go
@@ -3,6 +3,7 @@ package memai
 import (
 	"context"
 	"strings"
+	"unicode"
 )
 
 // emotionKeywordsJA maps emotion types to Japanese keyword triggers.
@@ -24,7 +25,7 @@ var emotionKeywordsJA = map[EmotionType][]string{
 		"ひどい", "酷い", "許せない", "ゆるせない",
 	},
 	EmotionFear: {
-		"心配", "不安", "怖い", "こわい", "大丈夫",
+		"心配", "不安", "怖い", "こわい",
 		"やばい", "ヤバい", "焦", "あせ", "緊張",
 		"ドキドキ", "どきどき", "恐",
 	},
@@ -59,7 +60,7 @@ var emotionKeywordsEN = map[EmotionType][]string{
 	},
 	EmotionSurprise: {
 		"wow", "omg", "unbelievable", "amazing", "incredible",
-		"shocking", "really", "seriously", "no way", "unexpected",
+		"shocking", "no way", "unexpected",
 	},
 }
 
@@ -73,17 +74,31 @@ var emotionValence = map[EmotionType]float64{
 	EmotionNeutral:  0.0,
 }
 
+// emotionOrder fixes the evaluation order of emotions. Ranging a map has a
+// randomized iteration order in Go, so iterating this slice instead guarantees
+// a deterministic winner when two emotions match the same number of keywords
+// (the earlier entry wins).
+var emotionOrder = []EmotionType{
+	EmotionJoy,
+	EmotionSadness,
+	EmotionAnger,
+	EmotionFear,
+	EmotionSurprise,
+}
+
 // AnalyzeEmotion detects emotion from a text message using keyword matching.
 // lang must be LangJapanese or LangEnglish; English matching is case-insensitive.
 // Returns EmotionNeutral with zero intensity if no emotional keywords are found.
 func AnalyzeEmotion(msg string, lang Language) *EmotionalState {
 	var keywords map[EmotionType][]string
 	var target string
+	var tokens map[string]struct{}
 
 	switch lang {
 	case LangEnglish:
 		keywords = emotionKeywordsEN
 		target = strings.ToLower(msg)
+		tokens = tokenizeEN(target)
 	default: // LangJapanese
 		keywords = emotionKeywordsJA
 		target = msg
@@ -92,10 +107,11 @@ func AnalyzeEmotion(msg string, lang Language) *EmotionalState {
 	bestEmotion := EmotionNeutral
 	bestCount := 0
 
-	for emotion, kws := range keywords {
+	// Iterate in a fixed order (not over the map) so ties resolve deterministically.
+	for _, emotion := range emotionOrder {
 		count := 0
-		for _, kw := range kws {
-			if strings.Contains(target, kw) {
+		for _, kw := range keywords[emotion] {
+			if matchKeyword(target, tokens, kw, lang) {
 				count++
 			}
 		}
@@ -137,6 +153,34 @@ func AnalyzeEmotion(msg string, lang Language) *EmotionalState {
 		Intensity: intensity,
 		Valence:   valence,
 	}
+}
+
+// tokenizeEN splits an already-lowercased English string into the set of its
+// word tokens (runs of letters/digits), used for whole-word keyword matching.
+func tokenizeEN(lower string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, tok := range strings.FieldsFunc(lower, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		set[tok] = struct{}{}
+	}
+	return set
+}
+
+// matchKeyword reports whether kw matches target. For English, single-word
+// keywords are matched against whole tokens (avoiding substring false positives
+// such as "miss" in "mission" or "fear" in "fearless"); multi-word keywords
+// (e.g. "no way") fall back to substring matching. Japanese has no word
+// separators, so substring matching is used as before.
+func matchKeyword(target string, tokens map[string]struct{}, kw string, lang Language) bool {
+	if lang == LangEnglish {
+		if strings.ContainsRune(kw, ' ') {
+			return strings.Contains(target, kw)
+		}
+		_, ok := tokens[kw]
+		return ok
+	}
+	return strings.Contains(target, kw)
 }
 
 // KeywordEmotionAnalyzer implements EmotionAnalyzer using keyword matching.

--- a/emotion_test.go
+++ b/emotion_test.go
@@ -125,3 +125,48 @@ func TestKeywordEmotionAnalyzer_English(t *testing.T) {
 		t.Errorf("expected sadness, got %s", es.Primary)
 	}
 }
+
+// Regression (#7): a keyword-count tie must resolve to the same emotion on
+// every run. "happy" (joy) vs "scared" (fear) is a 1-1 tie; joy must win
+// deterministically via emotionOrder.
+func TestAnalyzeEmotion_DeterministicTie(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		es := AnalyzeEmotion("happy scared", LangEnglish)
+		if es.Primary != EmotionJoy {
+			t.Fatalf("nondeterministic tie-break: got %s on iteration %d", es.Primary, i)
+		}
+	}
+}
+
+// Regression (#8): English keywords must match whole words, not substrings.
+func TestAnalyzeEmotion_EnglishNoSubstringFalsePositive(t *testing.T) {
+	cases := []string{
+		"I made dinner",        // "mad" must not match "made"
+		"the mission deadline", // "miss" must not match "mission"
+		"I am fearless",        // "fear" must not match "fearless"
+		"download the file",    // "down" must not match "download"
+		"check the storage",    // "rage" must not match "storage"
+	}
+	for _, msg := range cases {
+		es := AnalyzeEmotion(msg, LangEnglish)
+		if es.Primary != EmotionNeutral {
+			t.Errorf("expected neutral for %q, got %s (intensity %f)", msg, es.Primary, es.Intensity)
+		}
+	}
+}
+
+// Regression (#9): "really" is no longer a surprise keyword.
+func TestAnalyzeEmotion_ReallyNotSurprise(t *testing.T) {
+	es := AnalyzeEmotion("I really need this done.", LangEnglish)
+	if es.Primary != EmotionNeutral {
+		t.Errorf("expected neutral, got %s", es.Primary)
+	}
+}
+
+// Regression (#10): 大丈夫 (reassurance) must not be classified as fear.
+func TestAnalyzeEmotion_DaijobuNotFear(t *testing.T) {
+	es := AnalyzeEmotion("もう大丈夫だよ", LangJapanese)
+	if es.Primary == EmotionFear {
+		t.Errorf("大丈夫 should not be fear, got %s with valence %f", es.Primary, es.Valence)
+	}
+}

--- a/feedback.go
+++ b/feedback.go
@@ -7,33 +7,99 @@ const (
 	FeedbackBoostNegative = -0.05
 )
 
-var positivePatterns = []string{
+var positivePatternsJA = []string{
 	"ありがとう", "そうそう", "正解", "それそれ", "そうだよ",
 	"そうだね", "合ってる", "当たり", "さすが", "よく覚えてる",
 	"覚えてくれ",
 }
 
-var negativePatterns = []string{
+var negativePatternsJA = []string{
 	"違うよ", "違う!", "違う！", "それじゃない", "間違い",
 	"間違えてる", "ハズレ", "覚えてない", "忘れてる", "そうじゃなく",
 }
 
+// negationSuffixesJA are clause-level negators. When one of these immediately
+// follows a positive pattern, the positive token is actually part of a
+// correction (e.g. "正解じゃない", "覚えてくれてない") and must be treated as
+// negative rather than positive feedback.
+var negationSuffixesJA = []string{
+	"じゃない", "ではない", "じゃなく", "ではなく",
+	"でない", "てない", "ていない", "ない",
+}
+
+// English patterns are matched on a lowercased copy of the message.
+var positivePatternsEN = []string{
+	"thank", "exactly", "correct", "that's right", "thats right",
+	"you remembered", "you got it", "spot on", "good memory", "well remembered",
+}
+
+var negativePatternsEN = []string{
+	"wrong", "not right", "incorrect", "that's not it", "thats not it",
+	"you forgot", "don't remember", "dont remember", "didn't remember",
+	"didnt remember", "misremember",
+}
+
 // DetectFeedback analyzes a message for positive/negative feedback signals
-// about memory accuracy. Returns a boost delta:
+// about memory accuracy. lang selects the keyword set (LangJapanese or
+// LangEnglish; English matching is case-insensitive). Returns a boost delta:
 //
 //	positive → FeedbackBoostPositive (+0.05)
 //	negative → FeedbackBoostNegative (-0.05)
 //	neutral  → 0
-func DetectFeedback(message string) float64 {
-	for _, p := range positivePatterns {
-		if strings.Contains(message, p) {
-			return FeedbackBoostPositive
-		}
+//
+// Negative signals take precedence over positive ones, and (for Japanese) a
+// positive pattern immediately followed by a negation suffix is treated as
+// negative, so corrections like "正解じゃない" or "覚えてくれてない" are not
+// misclassified as praise.
+func DetectFeedback(message string, lang Language) float64 {
+	pos, neg := positivePatternsJA, negativePatternsJA
+	target := message
+	negationAware := true
+
+	if lang == LangEnglish {
+		pos, neg = positivePatternsEN, negativePatternsEN
+		target = strings.ToLower(message)
+		negationAware = false
 	}
-	for _, p := range negativePatterns {
-		if strings.Contains(message, p) {
-			return FeedbackBoostNegative
-		}
+
+	// Negation wins: an explicit negative correction takes precedence over any
+	// positive token in the same message (e.g. "ありがとう、でもそれじゃない").
+	if containsAny(target, neg) {
+		return FeedbackBoostNegative
+	}
+	// A positive pattern immediately negated is a correction, not praise.
+	if negationAware && negatedPositive(target, pos) {
+		return FeedbackBoostNegative
+	}
+	if containsAny(target, pos) {
+		return FeedbackBoostPositive
 	}
 	return 0
+}
+
+// containsAny reports whether s contains any of the given patterns.
+func containsAny(s string, patterns []string) bool {
+	for _, p := range patterns {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// negatedPositive reports whether any positive pattern in s is immediately
+// followed by a Japanese negation suffix.
+func negatedPositive(s string, positives []string) bool {
+	for _, p := range positives {
+		_, rest, found := strings.Cut(s, p)
+		if !found {
+			continue
+		}
+		for _, neg := range negationSuffixesJA {
+			if strings.HasPrefix(rest, neg) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/feedback_test.go
+++ b/feedback_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestDetectFeedback_Positive(t *testing.T) {
 	cases := []string{"ありがとう！", "そうそう、それ", "さすが"}
 	for _, msg := range cases {
-		if DetectFeedback(msg) != FeedbackBoostPositive {
+		if DetectFeedback(msg, LangJapanese) != FeedbackBoostPositive {
 			t.Errorf("expected positive for %q", msg)
 		}
 	}
@@ -14,14 +14,54 @@ func TestDetectFeedback_Positive(t *testing.T) {
 func TestDetectFeedback_Negative(t *testing.T) {
 	cases := []string{"違うよ", "それじゃない", "忘れてるよ"}
 	for _, msg := range cases {
-		if DetectFeedback(msg) != FeedbackBoostNegative {
+		if DetectFeedback(msg, LangJapanese) != FeedbackBoostNegative {
 			t.Errorf("expected negative for %q", msg)
 		}
 	}
 }
 
 func TestDetectFeedback_Neutral(t *testing.T) {
-	if DetectFeedback("明日の天気は？") != 0 {
+	if DetectFeedback("明日の天気は？", LangJapanese) != 0 {
 		t.Error("expected neutral feedback")
+	}
+}
+
+// Regression: a positive token embedded in a negation must not be scored
+// positive (issue #1).
+func TestDetectFeedback_NegatedPositive(t *testing.T) {
+	cases := []string{
+		"覚えてくれてないじゃん", // "覚えてくれ" + negation
+		"正解じゃない",      // "正解" + negation
+		"それそれじゃない",    // "それそれ" + negation
+	}
+	for _, msg := range cases {
+		if got := DetectFeedback(msg, LangJapanese); got != FeedbackBoostNegative {
+			t.Errorf("expected negative for negated phrase %q, got %v", msg, got)
+		}
+	}
+}
+
+// Regression: an explicit negative correction wins over a leading positive.
+func TestDetectFeedback_NegativeWins(t *testing.T) {
+	if got := DetectFeedback("ありがとう、でもそれじゃない", LangJapanese); got != FeedbackBoostNegative {
+		t.Errorf("expected negative when correction follows thanks, got %v", got)
+	}
+}
+
+func TestDetectFeedback_English(t *testing.T) {
+	positives := []string{"Thanks!", "Exactly", "That's right", "you remembered"}
+	for _, msg := range positives {
+		if got := DetectFeedback(msg, LangEnglish); got != FeedbackBoostPositive {
+			t.Errorf("expected positive for %q, got %v", msg, got)
+		}
+	}
+	negatives := []string{"no that's wrong", "not right", "you forgot", "that's not it"}
+	for _, msg := range negatives {
+		if got := DetectFeedback(msg, LangEnglish); got != FeedbackBoostNegative {
+			t.Errorf("expected negative for %q, got %v", msg, got)
+		}
+	}
+	if got := DetectFeedback("what time is the meeting?", LangEnglish); got != 0 {
+		t.Errorf("expected neutral, got %v", got)
 	}
 }

--- a/ltm.go
+++ b/ltm.go
@@ -5,16 +5,23 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 )
 
 // LTMConfig configures long-term memory search behavior.
+//
+// Inclusion is gated on cosine similarity alone (>= SimilarityThreshold, lowered
+// by EmotionalPrimeDelta when the user is emotional). The remaining factors
+// (feedback Boost, emotion, thread, date) only adjust the score used for
+// ranking the included results; they never resurrect a semantically irrelevant
+// memory.
 type LTMConfig struct {
 	SimilarityThreshold float64 // Minimum cosine similarity to include (default: 0.3)
-	TopK                int     // Maximum results to return (default: 10)
-	ThreadBoost         float64 // Score boost for same-thread memories (default: 0.1)
-	DateBoost           float64 // Score boost for matching date (default: 0.15)
-	DatePenalty         float64 // Score penalty for mismatched date (default: -0.2)
-	EmotionalBoost      float64 // Score boost factor for emotional memories (default: 0.12)
+	TopK                int     // Maximum results to return; <= 0 means no limit (default: 10)
+	ThreadBoost         float64 // Ranking boost for same-thread memories (default: 0.1)
+	DateBoost           float64 // Ranking boost for matching date (default: 0.15)
+	DatePenalty         float64 // Ranking penalty for mismatched date (default: -0.2)
+	EmotionalBoost      float64 // Ranking boost factor for emotional memories (default: 0.12)
 	EmotionalPrimeDelta float64 // Threshold reduction when user is emotional (default: 0.05)
 }
 
@@ -80,7 +87,14 @@ func (l *LTM[ID]) Search(ctx context.Context, q SearchQuery) ([]SearchResult[ID]
 			continue
 		}
 
-		score := CosineSimilarity(queryEmb, mem.Embedding)
+		// Inclusion is decided by cosine similarity alone (with emotional
+		// priming); the boosts below only affect ranking.
+		sim := CosineSimilarity(queryEmb, mem.Embedding)
+		if sim < threshold {
+			continue
+		}
+
+		score := sim
 
 		// Feedback boost
 		score += mem.Boost
@@ -93,37 +107,39 @@ func (l *LTM[ID]) Search(ctx context.Context, q SearchQuery) ([]SearchResult[ID]
 			score += l.config.ThreadBoost
 		}
 
-		// Date boost/penalty
-		if q.QueryDate != "" && mem.EventDate != "" {
-			if dateMatches(q.QueryDate, mem.EventDate, q.DateMonthOnly) {
-				if q.DateNegated {
-					score += l.config.DatePenalty
-				} else {
-					score += l.config.DateBoost
-				}
-			} else {
-				if q.DateNegated {
-					score += l.config.DateBoost
-				} else {
-					score += l.config.DatePenalty
-				}
-			}
-		}
+		// Date boost/penalty (ranking only)
+		score += l.dateDelta(q, mem)
 
-		if score >= threshold {
-			results = append(results, SearchResult[ID]{Memory: mem, Score: score})
-		}
+		results = append(results, SearchResult[ID]{Memory: mem, Score: score})
 	}
 
-	sort.Slice(results, func(i, j int) bool {
+	sort.SliceStable(results, func(i, j int) bool {
 		return results[i].Score > results[j].Score
 	})
 
-	if len(results) > l.config.TopK {
+	if l.config.TopK > 0 && len(results) > l.config.TopK {
 		results = results[:l.config.TopK]
 	}
 
 	return results, nil
+}
+
+// dateDelta returns the ranking adjustment for the date factor. It is zero
+// when either date is empty or cannot be parsed, so a malformed or
+// foreign-format date never penalizes a memory.
+func (l *LTM[ID]) dateDelta(q SearchQuery, mem Memory[ID]) float64 {
+	if q.QueryDate == "" || mem.EventDate == "" {
+		return 0
+	}
+	matched, ok := dateMatches(q.QueryDate, mem.EventDate, q.DateMonthOnly)
+	if !ok {
+		return 0
+	}
+	// matched != negated => the date is "as wanted" => boost; otherwise penalty.
+	if matched != q.DateNegated {
+		return l.config.DateBoost
+	}
+	return l.config.DatePenalty
 }
 
 // ApplyFeedback adjusts the boost value for the given memories.
@@ -136,21 +152,44 @@ func (l *LTM[ID]) ApplyFeedback(ctx context.Context, memoryIDs []ID, delta float
 	return nil
 }
 
-// dateMatches checks whether two date strings match.
-// If monthOnly is true, only compares year-month (YYYY-MM).
-func dateMatches(queryDate, memDate string, monthOnly bool) bool {
-	if monthOnly {
-		// Compare YYYY-MM prefix
-		if len(queryDate) >= 7 && len(memDate) >= 7 {
-			return queryDate[:7] == memDate[:7]
+// dateLayouts are the accepted date formats, tried in order. Both zero-padded
+// and non-padded numeric forms are accepted, along with RFC3339 timestamps and
+// year-month-only values.
+var dateLayouts = []string{
+	"2006-01-02", "2006-1-2", "2006/01/02", "2006/1/2",
+	time.RFC3339, "2006-01-02T15:04:05",
+	"2006-01", "2006-1", "2006/01", "2006/1",
+}
+
+// parseDate parses a date string using dateLayouts, returning ok=false if no
+// layout matches.
+func parseDate(s string) (time.Time, bool) {
+	for _, layout := range dateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
 		}
-		return false
 	}
-	// Compare full YYYY-MM-DD (first 10 chars)
-	if len(queryDate) >= 10 && len(memDate) >= 10 {
-		return queryDate[:10] == memDate[:10]
+	return time.Time{}, false
+}
+
+// dateMatches reports whether two date strings refer to the same date (or, when
+// monthOnly is true, the same year-month). ok is false when either string
+// cannot be parsed, so the caller can skip the date factor rather than treating
+// a parse failure as a mismatch. Parsing normalizes formatting differences
+// (e.g. "2026-6-17" matches "2026-06-17").
+func dateMatches(queryDate, memDate string, monthOnly bool) (matched, ok bool) {
+	q, ok1 := parseDate(queryDate)
+	m, ok2 := parseDate(memDate)
+	if !ok1 || !ok2 {
+		return false, false
 	}
-	return queryDate == memDate
+	if q.Year() != m.Year() || q.Month() != m.Month() {
+		return false, true
+	}
+	if monthOnly {
+		return true, true
+	}
+	return q.Day() == m.Day(), true
 }
 
 // CosineSimilarity computes the cosine similarity between two vectors.

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -127,3 +127,67 @@ func TestLTM_ThreadBoost(t *testing.T) {
 	}
 }
 
+// Regression (#4): a large feedback Boost must not admit a semantically
+// irrelevant (orthogonal) memory below the cosine threshold.
+func TestLTM_BoostDoesNotBypassThreshold(t *testing.T) {
+	store := &mockStore{
+		memories: []Memory[int]{
+			{ID: 1, Content: "irrelevant", Embedding: []float64{0, 1, 0}, Boost: 5.0},
+		},
+	}
+	ltm := NewLTM(store, nil, DefaultLTMConfig())
+	results, err := ltm.Search(context.Background(), SearchQuery{QueryEmbedding: []float64{1, 0, 0}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("orthogonal memory with high boost should be excluded, got %d results", len(results))
+	}
+}
+
+// Regression (#5): TopK <= 0 means "no limit", not "return nothing".
+func TestLTM_TopKZeroMeansNoLimit(t *testing.T) {
+	cfg := DefaultLTMConfig()
+	cfg.TopK = 0
+	store := &mockStore{
+		memories: []Memory[int]{
+			{ID: 1, Content: "a", Embedding: []float64{1, 0, 0}},
+			{ID: 2, Content: "b", Embedding: []float64{0.9, 0.1, 0}},
+		},
+	}
+	ltm := NewLTM(store, nil, cfg)
+	results, err := ltm.Search(context.Background(), SearchQuery{QueryEmbedding: []float64{1, 0, 0}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("TopK=0 should not truncate; expected 2 results, got %d", len(results))
+	}
+}
+
+// Regression (#6): date matching normalizes formatting differences and reports
+// ok=false for unparseable input.
+func TestDateMatches_Normalization(t *testing.T) {
+	cases := []struct {
+		q, m        string
+		monthOnly   bool
+		wantMatch   bool
+		wantParseOK bool
+	}{
+		{"2026-6-17", "2026-06-17", false, true, true},            // non-padded vs padded
+		{"2026/06/17", "2026-06-17", false, true, true},           // slash vs dash
+		{"2026-06-17T10:00:00Z", "2026-06-17", false, true, true}, // RFC3339 vs date
+		{"2026-06-18", "2026-06-17", false, false, true},          // different day
+		{"2026-06-01", "2026-06-30", true, true, true},            // month-only match
+		{"not-a-date", "2026-06-17", false, false, false},
+	}
+	for _, c := range cases {
+		matched, ok := dateMatches(c.q, c.m, c.monthOnly)
+		if ok != c.wantParseOK {
+			t.Errorf("dateMatches(%q,%q,%v) ok=%v, want %v", c.q, c.m, c.monthOnly, ok, c.wantParseOK)
+		}
+		if ok && matched != c.wantMatch {
+			t.Errorf("dateMatches(%q,%q,%v) matched=%v, want %v", c.q, c.m, c.monthOnly, matched, c.wantMatch)
+		}
+	}
+}

--- a/stm.go
+++ b/stm.go
@@ -3,6 +3,7 @@ package memai
 import (
 	"sort"
 	"strings"
+	"sync"
 )
 
 // STMConfig configures short-term memory behavior.
@@ -29,30 +30,62 @@ func DefaultSTMConfig() STMConfig {
 // STM manages short-term / working memory with activation-based decay.
 // Emotional items decay at a slower rate, modeling the amygdala's influence
 // on memory consolidation.
+//
+// All exported methods are safe for concurrent use.
 type STM struct {
+	mu     sync.Mutex
 	config STMConfig
 	items  []*WorkingMemoryItem
 }
 
-// NewSTM creates a new short-term memory manager.
+// NewSTM creates a new short-term memory manager. Non-positive MaxItems and
+// negative rate/boost/threshold fields are replaced with the DefaultSTMConfig
+// values so that a zero-value or partially-filled config cannot silently
+// wipe working memory or invert decay.
 func NewSTM(config STMConfig) *STM {
+	d := DefaultSTMConfig()
+	if config.MaxItems <= 0 {
+		config.MaxItems = d.MaxItems
+	}
+	if config.ActivationThreshold < 0 {
+		config.ActivationThreshold = d.ActivationThreshold
+	}
+	if config.NormalDecayRate < 0 {
+		config.NormalDecayRate = d.NormalDecayRate
+	}
+	if config.EmotionalDecayRate < 0 {
+		config.EmotionalDecayRate = d.EmotionalDecayRate
+	}
+	if config.RefreshBoost < 0 {
+		config.RefreshBoost = d.RefreshBoost
+	}
 	return &STM{config: config}
 }
 
-// Items returns the current working memory items.
+// Items returns a snapshot of the current working memory items. The returned
+// slice is a copy, so appending to it does not affect internal state (the
+// pointed-to items are shared).
 func (s *STM) Items() []*WorkingMemoryItem {
-	return s.items
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*WorkingMemoryItem, len(s.items))
+	copy(out, s.items)
+	return out
 }
 
 // SetItems replaces the working memory contents.
 func (s *STM) SetItems(items []*WorkingMemoryItem) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.items = items
 }
 
 // Update performs a full STM cycle: decay, emotional marking, refresh, eviction.
 func (s *STM) Update(turn int, message string, emotion *EmotionalState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.decay(turn)
-	s.markEmotional(emotion)
+	s.markEmotional(message, emotion)
 	s.refresh(message)
 	s.evict()
 }
@@ -60,6 +93,8 @@ func (s *STM) Update(turn int, message string, emotion *EmotionalState) {
 // Add inserts a new item into working memory, evicting the lowest-activation
 // item if capacity is exceeded.
 func (s *STM) Add(item *WorkingMemoryItem) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.items = append(s.items, item)
 	s.evict()
 }
@@ -85,13 +120,20 @@ func (s *STM) decay(currentTurn int) {
 	}
 }
 
-// markEmotional flags items as emotional when emotion intensity is high.
-func (s *STM) markEmotional(emotion *EmotionalState) {
+// markEmotional flags items as emotional when the current message carries
+// emotion (intensity > 0.3). Only items topically relevant to the message
+// (their keywords appear in it) are marked, so an emotional turn does not
+// retroactively tag unrelated items in working memory. The flag is sticky:
+// once set it persists, giving the item the slower EmotionalDecayRate.
+func (s *STM) markEmotional(message string, emotion *EmotionalState) {
 	if emotion == nil || emotion.Intensity <= 0.3 {
 		return
 	}
+	lower := strings.ToLower(message)
 	for _, item := range s.items {
-		item.Emotional = true
+		if itemMatchesMessage(item, lower) {
+			item.Emotional = true
+		}
 	}
 }
 
@@ -119,9 +161,9 @@ func (s *STM) evict() {
 	}
 	s.items = alive
 
-	// Enforce capacity
-	if len(s.items) > s.config.MaxItems {
-		sort.Slice(s.items, func(i, j int) bool {
+	// Enforce capacity (MaxItems <= 0 means no capacity limit).
+	if s.config.MaxItems > 0 && len(s.items) > s.config.MaxItems {
+		sort.SliceStable(s.items, func(i, j int) bool {
 			return s.items[i].Activation > s.items[j].Activation
 		})
 		s.items = s.items[:s.config.MaxItems]
@@ -137,4 +179,3 @@ func itemMatchesMessage(item *WorkingMemoryItem, lowerMsg string) bool {
 	}
 	return false
 }
-

--- a/stm_test.go
+++ b/stm_test.go
@@ -1,6 +1,9 @@
 package memai
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestSTM_Decay(t *testing.T) {
 	stm := NewSTM(DefaultSTMConfig())
@@ -98,3 +101,62 @@ func TestSTM_CapacityLimit(t *testing.T) {
 	}
 }
 
+// Regression (#3): an emotional message must only flag topically relevant
+// items, not every item in working memory.
+func TestSTM_MarkEmotionalOnlyRelevant(t *testing.T) {
+	stm := NewSTM(DefaultSTMConfig())
+	stm.SetItems([]*WorkingMemoryItem{
+		{Topic: "trip", Activation: 0.8, Keywords: []string{"旅行"}},
+		{Topic: "logistics", Activation: 0.8, Keywords: []string{"会議"}},
+	})
+
+	// Emotional message that only relates to the "trip" item.
+	stm.Update(0, "旅行が楽しみ", &EmotionalState{Primary: EmotionJoy, Intensity: 0.6})
+
+	items := stm.Items()
+	var trip, logistics *WorkingMemoryItem
+	for _, it := range items {
+		switch it.Topic {
+		case "trip":
+			trip = it
+		case "logistics":
+			logistics = it
+		}
+	}
+	if trip == nil || logistics == nil {
+		t.Fatal("expected both items to survive")
+	}
+	if !trip.Emotional {
+		t.Error("relevant item should be marked emotional")
+	}
+	if logistics.Emotional {
+		t.Error("unrelated item must NOT be marked emotional")
+	}
+}
+
+// Regression (#5): a zero-value config must not silently wipe working memory.
+func TestSTM_ZeroConfigDoesNotWipe(t *testing.T) {
+	stm := NewSTM(STMConfig{})
+	stm.Add(&WorkingMemoryItem{Topic: "A", Activation: 1.0, Keywords: []string{"a"}})
+	if len(stm.Items()) != 1 {
+		t.Fatalf("zero-value config wiped item; got %d items", len(stm.Items()))
+	}
+}
+
+// Regression (#2): concurrent Update/Add must not race or panic.
+func TestSTM_ConcurrentAccess(t *testing.T) {
+	stm := NewSTM(DefaultSTMConfig())
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				stm.Add(&WorkingMemoryItem{Topic: "x", Activation: 0.9, Keywords: []string{"x"}})
+				stm.Update(i, "x", &EmotionalState{Primary: EmotionJoy, Intensity: 0.6})
+				_ = stm.Items()
+			}
+		}(g)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
コードレビュー(8観点 × 敵対的検証)で再現確認した **High 2件・Medium 9件** の実装問題を修正します。修正後はさらに敵対的検証ワークフローで全項目が「解消済み・リグレッションなし」を確認済みです。

Closes #3

## 🔴 High
1. **`feedback.go` 符号反転**: 否定文(`覚えてくれてないじゃん`/`正解じゃない`/`それそれじゃない`/`ありがとう、でも〜じゃない`)がポジティブ判定され、誤った記憶のBoostを上げてLTMランキングを汚染していた → 否定優先＋否定接尾辞認識で解消。
2. **`stm.go` 並行クラッシュ**: mutex無しで `Update`/`Add` 並行時にデータレース＋`sort.Slice` の index out of range パニック → `sync.Mutex` 保護、`Items()` はコピー返却。

## 🟡 Medium
3. `stm.go` `markEmotional` が全アイテムを恒久フラグ化 → 関連性ゲート化(`itemMatchesMessage`)。
4. `ltm.go` しきい値がブースト後スコアに効いていた(doc は"コサイン類似度") → 包含はコサイン素値、Boost等はランキングのみ。
5. `stm.go`/`ltm.go` ゼロ値Config無検証 → `NewSTM` 正規化、`evict`/`Search` に `MaxItems>0`/`TopK>0`(`<=0`=無制限)ガード。
6. `ltm.go` `dateMatches` のバイト前方一致 → `time.Parse` 複数レイアウト化(`2026-6-17`≡`2026-06-17`、解析不能はスキップ)。
7. `emotion.go` 同点時の非決定性(map反復) → `emotionOrder` 固定順反復。
8. `emotion.go` 英語の部分一致誤検出(`fearless`/`made`/`storage` 等) → 語境界トークンマッチ。
9. `emotion.go` `really` を Surprise から除去。
10. `emotion.go` `大丈夫` を Fear から除去。
11. `feedback.go` 日本語専用 → `DetectFeedback(msg, lang)` で英語対応。

## テスト
- `go test -race`・`go vet`・`gofmt`・`go build` すべて合格。
- 各修正に回帰テストを追加(否定/並行/関連性/しきい値/TopK/日付正規化/決定性/語境界/EN)。

## ⚠️ 破壊的変更
- `DetectFeedback(message string)` → `DetectFeedback(message string, lang Language)`(感情側 `AnalyzeEmotion(msg, lang)` と整合)。呼び出し側・テスト・README更新済み。

## 残課題(Low、フォローアップ推奨)
二重否定 `覚えてないわけない`、`TurnAccessed` 命名、`Add` のターン未刻印、`CosineSimilarity` の NaN/Inf ガード、`ApplyFeedback` 部分適用、`EmotionAnalyzer` 注入シーム、並行性契約の明文化 等。
